### PR TITLE
fix: HaxeEnum 创建新实例时未复用原生单例导致枚举值匹配错误

### DIFF
--- a/sources/HashlinkSharp/Marshaling/DefaultHashlinkMarshaler.cs
+++ b/sources/HashlinkSharp/Marshaling/DefaultHashlinkMarshaler.cs
@@ -253,7 +253,7 @@ namespace Hashlink.Marshaling
                 TypeKind.HABSTRACT => (nint)((HL_vdynamic*)target)->val.ptr,
                 TypeKind.HFUN => new HashlinkClosure(ptr),
                 TypeKind.HREF => (nint)((HL_vdynamic*)target)->val.ptr,
-                TypeKind.HENUM => new HashlinkEnum(ptr),
+                TypeKind.HENUM => HashlinkEnum.CacheAndCreate(ptr),
                 TypeKind.HARRAY => new HashlinkArray(ptr),
                 TypeKind.HDYNOBJ => new HashlinkDynObj(ptr),
                 TypeKind.HNULL or TypeKind.HDYN => HashlinkMarshal.ReadData(

--- a/sources/HashlinkSharp/Proxy/Values/HashlinkEnum.cs
+++ b/sources/HashlinkSharp/Proxy/Values/HashlinkEnum.cs
@@ -7,10 +7,30 @@ namespace Hashlink.Proxy.Values
 {
     public unsafe class HashlinkEnum( HashlinkObjPtr objPtr ) : HashlinkTypedObj<HL_enum>(objPtr)
     {
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<(nint, int), nint> _singletons = new();
+
         public HashlinkEnum( HashlinkEnumType type, int index ) :
-            this(HashlinkObjPtr.Get(hl_alloc_enum(type.NativeType, index)))
+            this(HashlinkObjPtr.Get(GetOrCreateEnum(type, index)))
         {
             Debug.Assert(Handle != null);
+        }
+
+        private static nint GetOrCreateEnum( HashlinkEnumType type, int index )
+        {
+            var key = ((nint)type.NativeType, index);
+            return _singletons.TryGetValue(key, out var cached)
+                ? cached
+                : (nint)hl_alloc_enum(type.NativeType, index);
+        }
+
+        // DefaultHashlinkMarshaler 从游戏读取枚举时调用。
+        // 游戏中的枚举是单例——将其缓存，以便后续的 new Align.Center() 操作能复用原生代码用于身份验证的同一指针。
+        internal static HashlinkEnum CacheAndCreate( HashlinkObjPtr ptr )
+        {
+            var e = new HashlinkEnum(ptr);
+            if (e.Handle != null)
+                _singletons[((nint)e.EnumType.NativeType, e.Index)] = e.HashlinkPointer;
+            return e;
         }
         public HashlinkEnumType EnumType => (HashlinkEnumType)Type;
         public HashlinkEnumConstruct CurrentConstruct => EnumType.Constructs[Index];


### PR DESCRIPTION
Haxe 无参数枚举构造器使用单例，原生代码通过指针比较（而非 index 比较）
识别枚举值。原先 new Align.Center() 每次调用 hl_alloc_enum 分配新实例， 指针不匹配导致走到错误分支。

修复：
- 读路径（TryConvertHashlinkObject）遇到游戏枚举时，将 (type, index)→指针 缓存
- 创建路径（HashlinkEnum 构造）优先查缓存，命中则返回单例而非重新分配