### PR TITLE
fix: guard hl_gc_get_memsize calls against unregistered threads

### DIFF
--- a/sources/HashlinkSharp/Marshaling/ObjHandle/HashlinkObjManager.cs
+++ b/sources/HashlinkSharp/Marshaling/ObjHandle/HashlinkObjManager.cs
@@ -304,6 +304,10 @@ namespace Hashlink.Marshaling.ObjHandle
 
         private static nint* GetObjWrapperPtr( void* ptr )
         {
+            if (hl_get_thread() == null)
+            {
+                return null;
+            }
             var size = hl_gc_get_memsize(ptr);
             if (size <= 0)
             {

--- a/sources/HashlinkSharp/Proxy/HashlinkObj.cs
+++ b/sources/HashlinkSharp/Proxy/HashlinkObj.cs
@@ -54,7 +54,7 @@ namespace Hashlink.Proxy
         }
         public TypeKind TypeKind => Type.TypeKind;
         public bool IsValid => nativeType != null && type != null &&
-            HashlinkPointer != 0 && hl_gc_get_memsize((void*)HashlinkPointer) > 0;
+            HashlinkPointer != 0 && hl_get_thread() != null && hl_gc_get_memsize((void*)HashlinkPointer) > 0;
         public void Detach()
         {
             nativeType = null;


### PR DESCRIPTION
`HashlinkObj.IsValid` and `HashlinkObjManager.GetObjWrapperPtr` both called `hl_gc_get_memsize` unconditionally, which requires the calling thread to be registered with HashLink's GC via `hl_register_thread`. If called from any unregistered .NET thread (thread pool, async continuation, etc.), HashLink would fatal-error with `"Can't lock GC in unregistered thread" (gc.c:256).` This guard fixes this issue, also solving occasional crashes and errors with mods, especially DeadCellsMultiplayerMod:

<img width="437" height="186" alt="image" src="https://github.com/user-attachments/assets/f47d2541-7d99-45b1-b281-df46d87e5515" />
